### PR TITLE
hotfix CharacterObjectPatch.cs and SubModule.cs

### DIFF
--- a/Patches/CharacterObjectPatch.cs
+++ b/Patches/CharacterObjectPatch.cs
@@ -21,6 +21,13 @@ namespace CharacterCreation.Patches
         {
             if (__instance.IsHero)
             {
+                if (!__instance.IsPlayerCharacter)
+                {
+                    AccessTools.Property(typeof(Hero), "StaticBodyProperties").SetValue(__instance.HeroObject, properties.StaticProperties);
+                    __instance.HeroObject.DynamicBodyProperties = properties.DynamicProperties;
+                    __instance.HeroObject.UpdatePlayerGender(isFemale);
+                }
+
                 if (Settings.Instance != null && Settings.Instance.DebugMode)
                     InformationManager.DisplayMessage(new InformationMessage(HeroUpdatedMsg.ToString() + __instance.HeroObject.Name, ColorManager.Purple));
 

--- a/SubModule.cs
+++ b/SubModule.cs
@@ -35,8 +35,8 @@ namespace CharacterCreation
         {
             TextObject message = ExpectedActualAgeMessage.CopyTextObject();
             message.SetTextVariable("HERO_NAME", hero.Name);
-            message.SetTextVariable("AGE1", expectedAge);
-            message.SetTextVariable("AGE2", hero.Age);
+            message.SetTextVariable("AGE1", new TextObject(expectedAge.ToString()));
+            message.SetTextVariable("AGE2", new TextObject(hero.Age.ToString()));
             return message.ToString();
         }
 


### PR DESCRIPTION
* On review, CharacterObject.UpdatePlayerCharacterBodyProperties skipped body property updating for non-players. The patch is kept a postfix, but the code that sets the body properties are added back in for NPC heroes. My bad :D
* TextObject.SetTextVariable(string, float) has a different return type in e1.4.1 as in e1.4.0, which can cause the game to crash on the former version since the latter version likely uses the void return type. The fix has all three calls to TextObject.SetTextVariable use the (string, TextObject) overload, which has the void return type on both versions.