### PR TITLE
fix crash in e1.4.1 while maintaining compatibility with e1.4.0

### DIFF
--- a/SubModule.cs
+++ b/SubModule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Windows.Forms;
 using TaleWorlds.Core;
@@ -27,17 +28,17 @@ namespace CharacterCreation
             EditAppearanceForHeroMessage = new TextObject("{=CharacterCreation_EditAppearanceForHeroMessage}Entering edit appearance for: "),
             ErrorLoadingDccMessage = new TextObject("{=CharacterCreation_ErrorLoadingDccMessage}Error initializing Detailed Character Creation:");
             
-        private static readonly TextObject ExpectedActualAgeMessage = new TextObject("{=CharacterCreation_ExpectedActualAgeMessage}[Debug] Hero {HERO_NAME} expected age: {AGE1}, actual age: {AGE2}");
+        private const string ExpectedActualAgeMessage = "{=CharacterCreation_ExpectedActualAgeMessage}[Debug] Hero {HERO_NAME} expected age: {AGE1}, actual age: {AGE2}";
 
         public static CampaignTime TimeSinceLastSave { get; set; }
-        
+
         public static string GetFormattedAgeDebugMessage(Hero hero, float expectedAge)
         {
-            TextObject message = ExpectedActualAgeMessage.CopyTextObject();
-            message.SetTextVariable("HERO_NAME", hero.Name);
-            message.SetTextVariable("AGE1", new TextObject(expectedAge.ToString()));
-            message.SetTextVariable("AGE2", new TextObject(hero.Age.ToString()));
-            return message.ToString();
+            var attributes = new Dictionary<string, TextObject>();
+            attributes["HERO_NAME"] = hero.Name;
+            attributes["AGE1"] = new TextObject(expectedAge);
+            attributes["AGE2"] = new TextObject(hero.Age);
+            return new TextObject(ExpectedActualAgeMessage, attributes).ToString();
         }
 
         // Main


### PR DESCRIPTION
Fixed crash when loading the game with debug on in e1.4.1.

Of course, now that e1.4.1 went stable, compatibility with e1.4.0 is no longer necessary. Still, this modification should work on both version. Blame TaleWorlds for changing the return type of every TextObject.SetTextVariable() overload to TextObject (as compared to e1.4.0, which has void).

Also, MCM is now on version 3, so should we upgrade? 2.0.10 does work for the time being however due to compatibility with past MBO versions though.