### PR TITLE
Update SubModule.xml

### DIFF
--- a/!Export/Modules/zzCharacterCreation/SubModule.xml
+++ b/!Export/Modules/zzCharacterCreation/SubModule.xml
@@ -1,5 +1,5 @@
 ﻿<Module>
-  <Name value="Detailed Character Creation" />
+  <Name value="mzDetailed Character Creation" />
   <Id value="zzCharacterCreation" />
   <Version value="v1.1.6" />
   <SingleplayerModule value="true" />


### PR DESCRIPTION
Loading this mod before MCM causes a bug in the mod option screen. This is a dirty fix to the problem but there has to be a better way to fix this.

It might help to add MCM as a Nexus requirement, even though it is packaged into the mod, so that future versions of MCM will still work with this mod. Especially since the version packaged into the mod does not have compatibility with MCM v1/2 and ModLib.