### PR TITLE
Patch skins.xml loading and more

### DIFF
--- a/!Export/Modules/zzCharacterCreation/ModuleData/Languages/eng_module_strings.xml
+++ b/!Export/Modules/zzCharacterCreation/ModuleData/Languages/eng_module_strings.xml
@@ -5,35 +5,35 @@
   </tags>
   <strings>
     <!-- Settings entries -->
-    <string id="CharacterCration_ModNameText" text="Detailed Character Creation"/>
+    <string id="CharacterCreation_ModNameText" text="Detailed Character Creation"/>
     
-    <string id="CharacterCration_Section0" text="Section 0: Debug Mode"/>
-    <string id="CharacterCration_DebugModeName" text="Enable debug output"/>
-    <string id="CharacterCration_DebugModeHint" text="Enable DCC's debug output. Does NOT require restart."/>
+    <string id="CharacterCreation_Section0" text="Section 0: Debug Mode"/>
+    <string id="CharacterCreation_DebugModeName" text="Enable debug output"/>
+    <string id="CharacterCreation_DebugModeHint" text="Enable DCC's debug output. Does NOT require restart."/>
     
-    <string id="CharacterCration_Section1" text="Section 1: Overrides"/>
-    <string id="CharacterCration_IgnoreDailyTickName" text="Overrides"/>
-    <string id="CharacterCration_IgnoreDailyTickHint" text="Keep this on to prevent the game from reverting your appearance. Does NOT require restart."/>
-    <string id="CharacterCration_OverrideAgeName" text="Override Age"/>
-    <string id="CharacterCration_OverrideAgeHint" text="When enabled, this will prevent FaceGen from changing a hero's age. Does NOT require restart."/>
-    <string id="CharacterCration_DisableAutoAgingName" text="Disable Auto Aging"/>
-    <string id="CharacterCration_DisableAutoAgingHint" text="Enable this to prevent the game from changing the age physical appearance. Does NOT require restart."/>
+    <string id="CharacterCreation_Section1" text="Section 1: Overrides"/>
+    <string id="CharacterCreation_IgnoreDailyTickName" text="Overrides"/>
+    <string id="CharacterCreation_IgnoreDailyTickHint" text="Keep this on to prevent the game from reverting your appearance. Does NOT require restart."/>
+    <string id="CharacterCreation_OverrideAgeName" text="Override Age"/>
+    <string id="CharacterCreation_OverrideAgeHint" text="When enabled, this will prevent FaceGen from changing a hero's age. Does NOT require restart."/>
+    <string id="CharacterCreation_DisableAutoAgingName" text="Disable Auto Aging"/>
+    <string id="CharacterCreation_DisableAutoAgingHint" text="Enable this to prevent the game from changing the age physical appearance. Does NOT require restart."/>
 
-    <string id="CharacterCration_Section2" text="Section 2: Age Model"/>
-    <string id="CharacterCration_CustomAgeModelName" text="Custom Age Model"/>
-    <string id="CharacterCration_CustomAgeModelHint" text="Enable this to use a custom age model. Disable if another mod uses a custom age model. REQUIRES restart."/>
-    <string id="CharacterCration_BecomeInfantAgeName" text="Infant Age Stage"/>
-    <string id="CharacterCration_BecomeInfantAgeHint" text="Set the default infant stage age. Does NOT require restart."/>
-    <string id="CharacterCration_BecomeChildAgeName" text="Child Age Stage"/>
-    <string id="CharacterCration_BecomeChildAgeHint" text="Set the default child stage age. Does NOT require restart."/>
-    <string id="CharacterCration_BecomeTeenagerAgeName" text="Teenager Age Stage"/>
-    <string id="CharacterCration_BecomeTeenagerAgeHint" text="Set the default teenager stage age. Does NOT require restart."/>
-    <string id="CharacterCration_BecomeAdultAgeName" text="Adult Age Stage"/>
-    <string id="CharacterCration_BecomeAdultAgeHint" text="Set the default adult stage age. Does NOT require restart."/>
-    <string id="CharacterCration_BecomeOldAgeName" text="Old Age Stage"/>
-    <string id="CharacterCration_BecomeOldAgeHint" text="Set the default old stage age. Does NOT require restart."/>
-    <string id="CharacterCration_MaxAgeName" text="Max Age Stage"/>
-    <string id="CharacterCration_MaxAgeHint" text="Set the default max age. Does NOT require restart."/>
+    <string id="CharacterCreation_Section2" text="Section 2: Age Model"/>
+    <string id="CharacterCreation_CustomAgeModelName" text="Custom Age Model"/>
+    <string id="CharacterCreation_CustomAgeModelHint" text="Enable this to use a custom age model. Disable if another mod uses a custom age model. REQUIRES restart."/>
+    <string id="CharacterCreation_BecomeInfantAgeName" text="Infant Age Stage"/>
+    <string id="CharacterCreation_BecomeInfantAgeHint" text="Set the default infant stage age. Does NOT require restart."/>
+    <string id="CharacterCreation_BecomeChildAgeName" text="Child Age Stage"/>
+    <string id="CharacterCreation_BecomeChildAgeHint" text="Set the default child stage age. Does NOT require restart."/>
+    <string id="CharacterCreation_BecomeTeenagerAgeName" text="Teenager Age Stage"/>
+    <string id="CharacterCreation_BecomeTeenagerAgeHint" text="Set the default teenager stage age. Does NOT require restart."/>
+    <string id="CharacterCreation_BecomeAdultAgeName" text="Adult Age Stage"/>
+    <string id="CharacterCreation_BecomeAdultAgeHint" text="Set the default adult stage age. Does NOT require restart."/>
+    <string id="CharacterCreation_BecomeOldAgeName" text="Old Age Stage"/>
+    <string id="CharacterCreation_BecomeOldAgeHint" text="Set the default old stage age. Does NOT require restart."/>
+    <string id="CharacterCreation_MaxAgeName" text="Max Age Stage"/>
+    <string id="CharacterCreation_MaxAgeHint" text="Set the default max age. Does NOT require restart."/>
     
     <!-- SubModule entries -->
     <string id="CharacterCreation_LoadedModMessage" text="Loaded Detailed Character Creation."/>
@@ -69,5 +69,8 @@
     <string id="CharacterCreation_HeroNotFoundMsg" text="Hero is not found"/>
     <string id="CharacterCreation_EnterAgeMsg" text="Please enter an age."/>
     <string id="CharacterCreation_SuccessMsg" text="Success"/>
+    
+    <!-- ModuleProcessSkinxXmlPatch entry -->
+    <string id="CharacterCreation_ProcessSkinsXmlDebug" text="[CharacterCreation] Patching Skins XML to reverse file loading order"/>
   </strings>
 </base>

--- a/!Export/Modules/zzCharacterCreation/SubModule.xml
+++ b/!Export/Modules/zzCharacterCreation/SubModule.xml
@@ -1,5 +1,5 @@
 ﻿<Module>
-  <Name value="Detailed Character Creation" />
+  <Name value="mzDetailed Character Creation" />
   <Id value="zzCharacterCreation" />
   <Version value="v1.1.6" />
   <SingleplayerModule value="true" />

--- a/!Export/Modules/zzCharacterCreation/SubModule.xml
+++ b/!Export/Modules/zzCharacterCreation/SubModule.xml
@@ -1,10 +1,11 @@
 ﻿<Module>
-  <Name value="mzDetailed Character Creation" />
+  <Name value="Detailed Character Creation" />
   <Id value="zzCharacterCreation" />
   <Version value="v1.1.6" />
   <SingleplayerModule value="true" />
   <MultiplayerModule value="false" />
   <DependedModules>
+    <DependedModule Id="Native"/>
   </DependedModules>
   <SubModules>
     <SubModule>

--- a/CharacterCreation.csproj
+++ b/CharacterCreation.csproj
@@ -74,7 +74,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="cd &quot;$(OutDir)&quot;&#xD;&#xA;xcopy &quot;*.*&quot; &quot;$(ProjectDir)!Export\Modules\zzCharacterCreation\bin\Win64_Shipping_Client&quot; /s /y&#xD;&#xA;cd &quot;$(ProjectDir)!Export\Modules\&quot;&#xD;&#xA;xcopy &quot;zzCharacterCreation&quot; &quot;$(GameFolder)\Modules\zzCharacterCreation&quot; /s /y" />
+    <Exec Command="cd &quot;$(OutDir)&quot;&#xD;&#xA;xcopy &quot;*.*&quot; &quot;$(ProjectDir)!Export\Modules\zzCharacterCreation\bin\Win64_Shipping_Client\&quot; /s /y&#xD;&#xA;cd &quot;$(ProjectDir)!Export\Modules\&quot;&#xD;&#xA;xcopy &quot;zzCharacterCreation&quot; &quot;$(GameFolder)\Modules\zzCharacterCreation\&quot; /s /y" />
   </Target>
 
 </Project>

--- a/Patches/ModuleProcessSkinsXmlPatch.cs
+++ b/Patches/ModuleProcessSkinsXmlPatch.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Serialization;
+using HarmonyLib;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.ObjectSystem;
+
+namespace CharacterCreation.Patches
+{
+    [HarmonyPatch(typeof(Module), "CreateProcessedSkinsXMLForNative")]
+    public static class ModuleProcessSkinsXmlPatch
+    {
+        private static readonly TextObject DebugString =
+            new TextObject("{=CharacterCreation_ProcessSkinsXmlDebug}[CharacterCreation] Patching skins.xml loader to reverse file loading order");
+
+        [HarmonyPrefix]
+        public static bool Prefix(ref string __result, ref string baseSkinsXmlPath)
+        {
+            Debug.Print(DebugString.ToString());
+
+            // Why do I have to clone and modify two separate methods? - Designer225
+            List<string> elementNameList = new List<string>();
+            List<Tuple<string, string>> toBeMerged = new List<Tuple<string, string>>();
+            List<string> xsltList = new List<string>();
+
+            IEnumerable<MbObjectXmlInformation> mbprojXmlList = XmlResource.MbprojXmls.Where(x => x.Id == "soln_skins");
+            mbprojXmlList = mbprojXmlList.Reverse();
+
+            foreach (MbObjectXmlInformation mbprojXml in mbprojXmlList)
+            {
+                if (File.Exists(ModuleInfo.GetXmlPathForNative(mbprojXml.ModuleName, mbprojXml.Name)))
+                {
+                    elementNameList.Add(mbprojXml.Name);
+                    toBeMerged.Add(Tuple.Create(ModuleInfo.GetXmlPathForNative(mbprojXml.ModuleName, mbprojXml.Name), string.Empty));
+                }
+                string xsltPathForNative = ModuleInfo.GetXsltPathForNative(mbprojXml.ModuleName, mbprojXml.Name);
+                if (File.Exists(xsltPathForNative))
+                    xsltList.Add(xsltPathForNative);
+                else
+                    xsltList.Add("");
+            }
+            XmlDocument mergedXmlForNative = MBObjectManager.CreateMergedXmlFile(toBeMerged, xsltList, true);
+
+            System.IO.StringWriter stringWriter = new System.IO.StringWriter();
+            XmlTextWriter xmlTextWriter = new XmlTextWriter(stringWriter);
+            mergedXmlForNative.WriteTo(xmlTextWriter);
+            baseSkinsXmlPath = elementNameList.First();
+            __result = stringWriter.ToString();
+
+            return false;
+        }
+    }
+}

--- a/Patches/ModuleProcessSkinsXmlPatch.cs
+++ b/Patches/ModuleProcessSkinsXmlPatch.cs
@@ -31,8 +31,20 @@ namespace CharacterCreation.Patches
             List<Tuple<string, string>> toBeMerged = new List<Tuple<string, string>>();
             List<string> xsltList = new List<string>();
 
-            IEnumerable<MbObjectXmlInformation> mbprojXmlList = XmlResource.MbprojXmls.Where(x => x.Id == "soln_skins");
-            mbprojXmlList = mbprojXmlList.Reverse();
+            List<MbObjectXmlInformation> mbprojXmlList = XmlResource.MbprojXmls.Where(x => x.Id == "soln_skins").ToList();
+            //mbprojXmlList = mbprojXmlList.Reverse();
+
+            for (int i = 0; i < mbprojXmlList.Count; i++)
+            {
+                var mbproj = mbprojXmlList[i];
+
+                if (mbproj.ModuleName == "Native")
+                {
+                    mbprojXmlList.RemoveAt(i);
+                    mbprojXmlList.Add(mbproj);
+                    break;
+                }
+            }
 
             foreach (MbObjectXmlInformation mbprojXml in mbprojXmlList)
             {

--- a/Settings/Settings.Localisation.cs
+++ b/Settings/Settings.Localisation.cs
@@ -9,36 +9,36 @@ namespace CharacterCreation
 {
     public partial class DCCSettings
     {
-        private const string ModNameText = "{=CharacterCration_ModNameText}Detailed Character Creation",
+        private const string DisplayNameText = "{=CharacterCration_ModNameText}Detailed Character Creation",
             
-            Section0 = "{=CharacterCration_Section0}Section 0: Debug Mode",
-            DebugModeName = "{=CharacterCration_DebugModeName}Enable debug output",
-            DebugModeHint = "{=CharacterCration_DebugModeHint}Enable DCC's debug output. Does NOT require restart.",
+            Section0 = "{=CharacterCreation_Section0}Section 0: Debug Mode",
+            DebugModeName = "{=CharacterCreation_DebugModeName}Enable debug output",
+            DebugModeHint = "{=CharacterCreation_DebugModeHint}Enable DCC's debug output. Does NOT require restart.",
             
-            Section1 = "{=CharacterCration_Section1}Section 1: Overrides",
-            IgnoreDailyTickName = "{=CharacterCration_IgnoreDailyTickName}Overrides",
-            IgnoreDailyTickHint = "{=CharacterCration_IgnoreDailyTickHint}Keep this on to prevent the game from reverting your appearance. Does NOT require restart.",
-            OverrideAgeName = "{=CharacterCration_OverrideAgeName}Override Age",
-            OverrideAgeHint = "{=CharacterCration_OverrideAgeHint}When enabled, this will prevent FaceGen from changing a hero's age. Does NOT require restart.",
-            DisableAutoAgingName = "{=CharacterCration_DisableAutoAgingName}Disable Auto Aging",
-            DisableAutoAgingHint = "{=CharacterCration_DisableAutoAgingHint}Enable this to prevent the game from changing the age physical appearance. Does NOT require restart.",
+            Section1 = "{=CharacterCreation_Section1}Section 1: Overrides",
+            IgnoreDailyTickName = "{=CharacterCreation_IgnoreDailyTickName}Overrides",
+            IgnoreDailyTickHint = "{=CharacterCreation_IgnoreDailyTickHint}Keep this on to prevent the game from reverting your appearance. Does NOT require restart.",
+            OverrideAgeName = "{=CharacterCreation_OverrideAgeName}Override Age",
+            OverrideAgeHint = "{=CharacterCreation_OverrideAgeHint}When enabled, this will prevent FaceGen from changing a hero's age. Does NOT require restart.",
+            DisableAutoAgingName = "{=CharacterCreation_DisableAutoAgingName}Disable Auto Aging",
+            DisableAutoAgingHint = "{=CharacterCreation_DisableAutoAgingHint}Enable this to prevent the game from changing the age physical appearance. Does NOT require restart.",
             
-            Section2 = "{=CharacterCration_Section2}Section 2: Age Model",
-            CustomAgeModelName = "{=CharacterCration_CustomAgeModelName}Custom Age Model",
-            CustomAgeModelHint = "{=CharacterCration_CustomAgeModelHint}Enable this to use a custom age model. Disable if another mod uses a custom age model. REQUIRES restart.",
-            BecomeInfantAgeName = "{=CharacterCration_BecomeInfantAgeName}Infant Age Stage",
-            BecomeInfantAgeHint = "{=CharacterCration_BecomeInfantAgeHint}Set the default infant stage age. Does NOT require restart.",
-            BecomeChildAgeName = "{=CharacterCration_BecomeChildAgeName}Child Age Stage",
-            BecomeChildAgeHint = "{=CharacterCration_BecomeChildAgeHint}Set the default child stage age. Does NOT require restart.",
-            BecomeTeenagerAgeName = "{=CharacterCration_BecomeTeenagerAgeName}Teenager Age Stage",
-            BecomeTeenagerAgeHint = "{=CharacterCration_BecomeTeenagerAgeHint}Set the default teenager stage age. Does NOT require restart.",
-            BecomeAdultAgeName = "{=CharacterCration_BecomeAdultAgeName}Adult Age Stage",
-            BecomeAdultAgeHint = "{=CharacterCration_BecomeAdultAgeHint}Set the default adult stage age. Does NOT require restart.",
-            BecomeOldAgeName = "{=CharacterCration_BecomeOldAgeName}Old Age Stage",
-            BecomeOldAgeHint = "{=CharacterCration_BecomeOldAgeHint}Set the default old stage age. Does NOT require restart.",
-            MaxAgeName = "{=CharacterCration_MaxAgeName}Max Age Stage",
-            MaxAgeHint = "{=CharacterCration_MaxAgeHint}Set the default max age. Does NOT require restart.";
+            Section2 = "{=CharacterCreation_Section2}Section 2: Age Model",
+            CustomAgeModelName = "{=CharacterCreation_CustomAgeModelName}Custom Age Model",
+            CustomAgeModelHint = "{=CharacterCreation_CustomAgeModelHint}Enable this to use a custom age model. Disable if another mod uses a custom age model. REQUIRES restart.",
+            BecomeInfantAgeName = "{=CharacterCreation_BecomeInfantAgeName}Infant Age Stage",
+            BecomeInfantAgeHint = "{=CharacterCreation_BecomeInfantAgeHint}Set the default infant stage age. Does NOT require restart.",
+            BecomeChildAgeName = "{=CharacterCreation_BecomeChildAgeName}Child Age Stage",
+            BecomeChildAgeHint = "{=CharacterCreation_BecomeChildAgeHint}Set the default child stage age. Does NOT require restart.",
+            BecomeTeenagerAgeName = "{=CharacterCreation_BecomeTeenagerAgeName}Teenager Age Stage",
+            BecomeTeenagerAgeHint = "{=CharacterCreation_BecomeTeenagerAgeHint}Set the default teenager stage age. Does NOT require restart.",
+            BecomeAdultAgeName = "{=CharacterCreation_BecomeAdultAgeName}Adult Age Stage",
+            BecomeAdultAgeHint = "{=CharacterCreation_BecomeAdultAgeHint}Set the default adult stage age. Does NOT require restart.",
+            BecomeOldAgeName = "{=CharacterCreation_BecomeOldAgeName}Old Age Stage",
+            BecomeOldAgeHint = "{=CharacterCreation_BecomeOldAgeHint}Set the default old stage age. Does NOT require restart.",
+            MaxAgeName = "{=CharacterCreation_MaxAgeName}Max Age Stage",
+            MaxAgeHint = "{=CharacterCreation_MaxAgeHint}Set the default max age. Does NOT require restart.";
 
-        private static readonly TextObject ModNameTextObject = new TextObject(ModNameText);
+        private static readonly TextObject DisplayNameTextObject = new TextObject(DisplayNameText);
     }
 }

--- a/Settings/Settings.cs
+++ b/Settings/Settings.cs
@@ -8,7 +8,7 @@ namespace CharacterCreation
     public partial class DCCSettings : AttributeGlobalSettings<DCCSettings>
     {
         public override string Id => "DCCSettings";
-        public override string DisplayName => "Detailed Character Creation";
+        public override string DisplayName => DisplayNameTextObject.ToString();
         public override string FolderName => "DetailedCharacterCreation";
 
         [XmlElement]


### PR DESCRIPTION
The game combines skins.xml documents and seems to use the first `skins` array element (or the first matching `skin` nodes; implementation unclear) in the combined document for FaceGen. This means the extra sliders only show up if they are in a mod that is loaded before Native.

The patch I have written has Native's skins.xml loaded last. This would maintain (a degree of) compatibility with skins.xml mods while guaranteeing that Native won't override modded skins.xml files. It also means (hopefully) that DCC's skins.xml will be loaded first, absent other modded skins.xml files.

It's still a relatively dirty fix, but it avoids having to change the mod's name in the launcher (pull request #7, closed that one because things escalated quickly).

SubModule.xml is also updated to address it causing MCM to bug out by loading its package before the standalone. Since MCM loads before Native anyway, this change goes with the above. (It would probably be wise to add MCM Standalone as a Nexus requirement, since people who install MCM likely have also installed ModLib; the integrated package inside DCC does not have compatibility with ModLib.)

Fixed a couple of typos in localization - this unfortunately will break all existing localizations of `DCCSettings` (which accounts for half of the game's localization strings).

Also fixed post-build directives because to `xcopy`, a folder is only a folder if it ends with a back slash.

Update: this only works for e1.4.2 as the ability to mod skins.xml is only added for that version.