### PR TITLE
Fixed build for latest version

### DIFF
--- a/CharacterCreation.csproj
+++ b/CharacterCreation.csproj
@@ -7,7 +7,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- Define your GameFolder here to simplify loading plugins and output dirs -->
-    <GameFolder>C:\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord</GameFolder>
+    <GameFolder>$(BANNERLORD_GAME_DIR)</GameFolder>
     <!--<GameFolder>D:\SteamLibrary\steamapps\common\Mount &amp; Blade II Bannerlord</GameFolder>-->
     <AssemblyName>CharacterCreation</AssemblyName>
     <Platforms>AnyCPU;x64</Platforms>
@@ -49,7 +49,7 @@
       <HintPath>%(Identity)</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="$(GameFolder)\bin\Win64_Shipping_Client\TaleWorlds.*.dll">
+    <Reference Include="$(GameFolder)\bin\Win64_Shipping_Client\TaleWorlds.*.dll" Exclude="$(GameFolder)\bin\Win64_Shipping_Client\TaleWorlds.Native.dll">
       <HintPath>%(Identity)</HintPath>
       <Private>False</Private>
     </Reference>

--- a/Models/ViewModel/EncyclopediaPageChangedAction.cs
+++ b/Models/ViewModel/EncyclopediaPageChangedAction.cs
@@ -39,7 +39,7 @@ namespace CharacterCreation.Models
         {
             if (Mission.Current != null) return; // do not allow edit if in mission as it could screw things up
 
-            EncyclopediaData.EncyclopediaPages newPage = e.NewPage;
+            EncyclopediaPages newPage = e.NewPage;
             if ((int)newPage != 12)
             {
                 selectedHeroPage = null;

--- a/SubModule.cs
+++ b/SubModule.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.ViewModelCollection.Encyclopedia;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;


### PR DESCRIPTION
Bannerlord install directory is now configurable as an environment variable BANNERLORD_GAME_DIR to support developing with Bannerlord installed in a different directory/drive (my steam library is on D:)