### PR TITLE
Rework of the aspect ratio logic

### DIFF
--- a/!Export/Modules/zzCharacterCreation/GUI/Prefabs/DCCHeroEditor.xml
+++ b/!Export/Modules/zzCharacterCreation/GUI/Prefabs/DCCHeroEditor.xml
@@ -6,7 +6,7 @@
   <Window>
     <Widget HeightSizePolicy ="StretchToParent" DoNotAcceptEvents="true" PositionYOffset="50" WidthSizePolicy="StretchToParent" Brush="Encyclopedia.Page.SoundBrush">
       <Children>
-        <ListPanel DoNotAcceptEvents="true" WidthSizePolicy="CoverChildren" HeightSizePolicy="Fixed" SuggestedHeight="75" HorizontalAlignment="Right" VerticalAlignment="Top" MarginTop="@AspectMarginTop" MarginBottom="@AspectMarginBottom" MarginRight="@AspectMarginRight">
+        <ListPanel DoNotAcceptEvents="true" WidthSizePolicy="CoverChildren" HeightSizePolicy="Fixed" SuggestedHeight="75" HorizontalAlignment="Right" VerticalAlignment="Top" MarginTop="@AspectMarginTop" MarginRight="@AspectMarginRight">
           <Children>
             <TextWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="170" SuggestedHeight="40" VerticalAlignment="Center" Brush="Popup.Button.Text" Text="@DCCOptionsString" />
             <ButtonWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="170" SuggestedHeight="40" DoNotPassEventsToChildren="true" VerticalAlignment="Center" Command.Click="ExecuteEdit" Brush="ButtonBrush4" UpdateChildrenStates="true" IsEnabled="true">

--- a/!Export/Modules/zzCharacterCreation/GUI/Prefabs/DCCTroopEditor.xml
+++ b/!Export/Modules/zzCharacterCreation/GUI/Prefabs/DCCTroopEditor.xml
@@ -6,7 +6,7 @@
   <Window>
     <Widget HeightSizePolicy ="StretchToParent" DoNotAcceptEvents="true" PositionYOffset="50" WidthSizePolicy="StretchToParent" Brush="Encyclopedia.Page.SoundBrush">
       <Children>
-        <ListPanel DoNotAcceptEvents="true" WidthSizePolicy="CoverChildren" HeightSizePolicy="Fixed" SuggestedHeight="75" HorizontalAlignment="Right" VerticalAlignment="Top" MarginTop="@AspectMarginTop" MarginBottom="@AspectMarginBottom" MarginRight="@AspectMarginRight">
+        <ListPanel DoNotAcceptEvents="true" WidthSizePolicy="CoverChildren" HeightSizePolicy="Fixed" SuggestedHeight="75" HorizontalAlignment="Right" VerticalAlignment="Top" MarginTop="@AspectMarginTop" MarginRight="@AspectMarginRight">
           <Children>
             <TextWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="170" SuggestedHeight="40" VerticalAlignment="Center" Brush="Popup.Button.Text" Text="@DCCOptionsString" />
             <ButtonWidget WidthSizePolicy="Fixed" HeightSizePolicy="Fixed" SuggestedWidth="170" SuggestedHeight="40" DoNotPassEventsToChildren="true" VerticalAlignment="Center" Command.Click="ExecuteEdit" Brush="ButtonBrush4" UpdateChildrenStates="true" IsEnabled="true">

--- a/UI/UnitBuilderVM.cs
+++ b/UI/UnitBuilderVM.cs
@@ -32,13 +32,10 @@ namespace CharacterCreation.UI
         public string ChangeNameString => ChangeNameText.ToString();
 
         [DataSourceProperty]
-        public int AspectMarginTop => AspectRatioUtil.GetMarginForAspectRatio((int)AspectRatioUtil.MarginType.Top);
+        public int AspectMarginTop => MarginUtil.GetTopMarginForAspectRatio();
 
         [DataSourceProperty]
-        public int AspectMarginBottom => AspectRatioUtil.GetMarginForAspectRatio((int)AspectRatioUtil.MarginType.Bottom);
-
-        [DataSourceProperty]
-        public int AspectMarginRight => AspectRatioUtil.GetMarginForAspectRatio((int)AspectRatioUtil.MarginType.Right);
+        public int AspectMarginRight => MarginUtil.GetRightMarginForAspectRatio();
 
         [DataSourceProperty]
         public string UndoAppearanceString => UndoAppearanceText.ToString();
@@ -91,7 +88,6 @@ namespace CharacterCreation.UI
                 gauntletEncyclopediaScreenManager.CloseEncyclopedia();
         }
 
-        private float aspectRatio = AspectRatioUtil.GetAspectRatio();
         private CharacterObject selectedUnit;
         private EncyclopediaPageVM selectedUnitPage;
     }

--- a/Util/GetAspectRatio.cs
+++ b/Util/GetAspectRatio.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using TaleWorlds.Engine;
 
 namespace CharacterCreation.Util

--- a/Util/GetAspectRatio.cs
+++ b/Util/GetAspectRatio.cs
@@ -1,60 +1,31 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using TaleWorlds.Engine;
 
 namespace CharacterCreation.Util
 {
-    public static class AspectRatioUtil
+    public static class MarginUtil
     {
-        public enum MarginType
+        // I think this is probably a better approach than the margin
+        // library, however, I'm sure someone with more experience in
+        // this field could improve this. It's accurate enough to 
+        // work, though ~ PoPo
+
+        public static int GetTopMarginForAspectRatio()
         {
-            Left = 0,
-            Top = 1,
-            Bottom = 2,
-            Right = 3
+            // This isn't entirely accurate, but it's very close -- should suffice
+            double a = 686.6034216162005;
+            double b = -2.6609724694782133;
+
+            return (int)(a * Math.Pow(Screen.AspectRatio, b) + 10);
         }
 
-        private static readonly Dictionary<(float, float), (int, int, int, int)> aspectRatioMarginMap = new Dictionary<(float, float), (int, int, int, int)>
+        public static int GetRightMarginForAspectRatio()
         {
-            // (RangeMin, RangeMax) (MarginTop, MarginBottom, MarginRight)
-            {(0.95f, 1.05f), (0, 0, 0, 0)},     // Approximately 1:1 {Unorthodox aspect}
-            {(1.1f, 1.27f), (0, 390, 0, 350)},  // Approximately 5:4
-            {(1.28f, 1.35f), (0, 340, 0, 360)}, // Approximately 4:3
-            {(1.58f, 1.65f), (0, 210, 0, 370)}, // Approximately 8:5 / 16:10 //verify
-            {(1.55f, 1.57f), (0, 220, 0, 370)}, // Approximately 25:16
-            {(1.66f, 1.9f), (0, 155, 0, 370)},  // Approximately 16:9
-            {(1.91f, 2.5f), (0, 0, 0, 0)},      // Approximately 2.35:1 {Unorthodox aspect range}
-            {(2.51f, 2.6f), (0, 0, 0, 0)},      // Approximately 21:9 // Don't have a 21:9 setup for testing
-        };
+            double a = 80;
+            double b = 262.5;
 
-        public static int GetMarginForAspectRatio(int type)
-        {
-            float aspectRatio = GetAspectRatio();
-            foreach (var entry in aspectRatioMarginMap)
-            {
-                var (minRatio, maxRatio) = entry.Key;
-                if (aspectRatio >= minRatio && aspectRatio <= maxRatio)
-                {
-                    // Determine which margin type to return based on the 'type' parameter
-                    switch (type)
-                    {
-                        case 0: // Left margin
-                            return entry.Value.Item1;
-                        case 1: // Top margin
-                            return entry.Value.Item2;
-                        case 2: // Bottom margin
-                            return entry.Value.Item3;
-                        case 3: // Right margin
-                            return entry.Value.Item4;
-                        default: // Default case
-                            return 0;
-                    }
-                }
-            }
-            return 0; // Default value for non-defined aspect ratios
-        }
-        public static float GetAspectRatio()
-        {
-            return Screen.AspectRatio;
+            return (int)(a * Screen.AspectRatio + b ) - 25;
         }
     }
 }


### PR DESCRIPTION
This isn't entirely perfect, but it's accurate enough that it should suffice for our needs.

It's at least (I think) a better approach than having a custom margin offset library that may require custom tweaking for non-native resolutions, such as people manually resizing the game window.

At least this way it should dynamically fit regardless of the aspect ratio of the game client.